### PR TITLE
Correcting the license boilerplate

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -175,7 +175,7 @@
 
    END OF TERMS AND CONDITIONS
 
-   Copyright 2017 PREBID.ORG, INC
+   Copyright 2021 IAB Technology Laboratory, Inc
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
I pulled the corporation naming from https://github.com/InteractiveAdvertisingBureau/iabtcf/blob/master/LICENSE