### PR TITLE
fix failing test cases and refactor timestamp and nonce

### DIFF
--- a/examples/signer/example-signer.go
+++ b/examples/signer/example-signer.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"bytes"
+	crypto_rand "crypto/rand"
 	"flag"
 	"fmt"
 	"net/http"
@@ -35,7 +36,7 @@ func main() {
 
 	demoClient := DemoClient{
 		Signer: adscert.NewAuthenticatedConnectionsSigner(
-			adscertcrypto.NewLocalAuthenticatedConnectionsSignatory(*originCallsign, privateKeysBase64, *useFakeKeyGeneratingDNS)),
+			adscertcrypto.NewLocalAuthenticatedConnectionsSignatory(*originCallsign, privateKeysBase64, *useFakeKeyGeneratingDNS), crypto_rand.Reader),
 
 		Method:         *method,
 		DestinationURL: *destinationURL,

--- a/examples/verifier/example-verifier.go
+++ b/examples/verifier/example-verifier.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	crypto_rand "crypto/rand"
 	"flag"
 	"fmt"
 	"io/ioutil"
@@ -26,7 +27,7 @@ func main() {
 
 	demoServer := &DemoServer{
 		Signer: adscert.NewAuthenticatedConnectionsSigner(
-			adscertcrypto.NewLocalAuthenticatedConnectionsSignatory(*hostCallsign, privateKeysBase64, *useFakeKeyGeneratingDNS)),
+			adscertcrypto.NewLocalAuthenticatedConnectionsSignatory(*hostCallsign, privateKeysBase64, *useFakeKeyGeneratingDNS), crypto_rand.Reader),
 	}
 	http.HandleFunc("/request", demoServer.HandleRequest)
 	http.ListenAndServe(":8090", nil)

--- a/internal/adscertcounterparty/counterparty_manager.go
+++ b/internal/adscertcounterparty/counterparty_manager.go
@@ -98,8 +98,12 @@ func NewCounterpartyManager(dnsResolver DNSResolver, base64PrivateKeys []string)
 	// Ideally rotation to a new signing key doesn't happen all-at-once but can instead be rolled
 	// out in a controlled fashion.
 	for _, privateKey := range cm.myPrivateKeys {
-		cm.currentPrivateKey = privateKey.alias
-		break
+		// since iterating over a map is non-deterministic, we can make sure to set the key
+		// either if it is not already set or it is alphabetically less than current key at the index when
+		// iterating over the private keys map.
+		if cm.currentPrivateKey == "" || cm.currentPrivateKey < privateKey.alias {
+			cm.currentPrivateKey = privateKey.alias
+		}
 	}
 
 	cm.counterparties.Store(counterpartyMap{})

--- a/pkg/adscert/authenticated_connections_signer_api.go
+++ b/pkg/adscert/authenticated_connections_signer_api.go
@@ -1,7 +1,8 @@
 package adscert
 
 import (
-	crypto_rand "crypto/rand"
+	"io"
+	"time"
 
 	"github.com/IABTechLab/adscert/pkg/adscertcrypto"
 )
@@ -16,10 +17,10 @@ type AuthenticatedConnectionsSigner interface {
 
 // NewAuthenticatedConnectionsSigner creates a new signer instance for creating
 // ads.cert Authenticated Connections signatures.
-func NewAuthenticatedConnectionsSigner(signatory adscertcrypto.AuthenticatedConnectionsSignatory) AuthenticatedConnectionsSigner {
+func NewAuthenticatedConnectionsSigner(signatory adscertcrypto.AuthenticatedConnectionsSignatory, reader io.Reader) AuthenticatedConnectionsSigner {
 	return &authenticatedConnectionsSigner{
 		signatory:    signatory,
-		secureRandom: crypto_rand.Reader,
+		secureRandom: reader,
 	}
 }
 
@@ -36,9 +37,11 @@ type AuthenticatedConnectionSignatureParams struct {
 	// that output the hash as raw bytes or base64 encoded... maybe the API provides the option
 	// to choose which variant is easier to work with depending on the logging technique they use.
 
-
 	// When verifying an existing set of signatures, also include these values.
 	SignatureMessageToVerify []string
+
+	// optional field to pass as custom time.
+	CustomTime func() time.Time
 }
 
 // AuthenticatedConnectionSignature represents a signature conforming to the

--- a/pkg/adscert/authenticated_connections_signer_impl.go
+++ b/pkg/adscert/authenticated_connections_signer_impl.go
@@ -23,8 +23,13 @@ func (c *authenticatedConnectionsSigner) SignAuthenticatedConnection(params Auth
 	response := AuthenticatedConnectionSignature{}
 	signatureRequest := adscertcrypto.AuthenticatedConnectionSigningPackage{}
 
-	// Time is UTC.
-	signatureRequest.Timestamp = time.Now().Format("060102T150405")
+	// if custom time function exists in params
+	customTime := params.CustomTime
+	if customTime == nil {
+		// otherwise fall back to original time.Now function
+		customTime = time.Now
+	}
+	signatureRequest.Timestamp = customTime().UTC().Format("060102T150405")
 
 	if signatureRequest.Nonce, err = c.generateNonce(); err != nil {
 		return response, err


### PR DESCRIPTION
- Allow `NewAuthenticatedConnectionsSigner` to accept a custom random reader as param.
- Update `AuthenticatedConnectionSignatureParams` to accept custom time function in order to mock timestamp in tests.
- Refactor tests setup code in `authenticated_connections_example_test.go`.
- Fix failing tests output check.
- Remove non-determinism in key selection.
- Modify `SignAuthenticatedConnection` method logic to accept custom time object.