### PR TITLE
Apply go standard version format for tagging

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -55,3 +55,4 @@ jobs:
         uses: anothrNick/github-tag-action@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WITH_V: true


### PR DESCRIPTION
- Add v to version tagging to comply with Golang standard versioning format
- Tested different go versions but kept the version as it is for now (1.15)

![Screen Shot 2021-06-16 at 10 35 01 AM](https://user-images.githubusercontent.com/56240400/122238993-92e39b80-ce8e-11eb-980a-ce2bd169af89.png)
