### PR TITLE
generate protobuf files in standardized build env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+
+# generate protobuf/grpc code
+build-protoc-env:
+	@echo ">>> building protoc environment"
+	DOCKER_SCAN_SUGGEST=false docker build . -f api/Dockerfile --tag adscert-protoc-env:latest
+
+build-protoc: build-protoc-env
+	@echo ">>> building protoc environment"
+	docker run \
+		-v $$(pwd):/go/src/github.com/IABTechLab/adscert \
+		-w /go/src/github.com/IABTechLab/adscert \
+		-it adscert-protoc-env:latest \
+		protoc \
+			--go_out=./pkg/adscert/api \
+			--go_opt=module=github.com/IABTechLab/adscert/pkg/adscert/api \
+			--go-grpc_out=./ \
+			--go-grpc_opt=module=github.com/IABTechLab/adscert \
+			./api/adscert.proto
+
+build-grpc-server:
+	@echo ">>> build grpc/server app"
+	go build ./cmd/server
+
+build-grpc-server-container:
+	@echo ">>> build docker container"
+	docker build -t adscert:latest .

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,0 +1,16 @@
+FROM golang:1.15.13-stretch
+
+RUN apt-get update \
+    && apt-get install -y unzip
+
+RUN GO111MODULE=on go get -u google.golang.org/protobuf/cmd/protoc-gen-go@v1.26 \
+    && git clone --depth 1 --branch v1.39.0 https://github.com/grpc/grpc-go /go/src/google.golang.org/grpc \
+    && cd /go/src/google.golang.org/grpc/cmd/protoc-gen-go-grpc \
+    && go install ./... \
+    && mkdir -p /tmp/protoc \
+    && cd /tmp/protoc \
+    && curl -L https://github.com/protocolbuffers/protobuf/releases/download/v3.17.3/protoc-3.17.3-linux-x86_64.zip \
+        --output /tmp/protoc-3.17.3-linux-x86_64.zip \
+    && unzip /tmp/protoc-3.17.3-linux-x86_64.zip \
+    && mv include/ /usr/local/ \
+    && mv bin/protoc /usr/bin/

--- a/build.sh
+++ b/build.sh
@@ -1,8 +1,0 @@
-# generate protobuf/grpc code
-protoc --go_out=. --go_opt=module=github.com/IABTechLab/adscert --go-grpc_out=. --go-grpc_opt=module=github.com/IABTechLab/adscert ./api/adscert.proto
-
-# build grpc/server app
-go build ./cmd/server
-
-# build docker container
-### docker build -t adscert:latest .


### PR DESCRIPTION
while the protobuf may not change drastically, having a standardized building env will help with file generation consistency.
