### PR TITLE
Config params for domain check and renewal intervals

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,11 @@ WORKDIR /app
 RUN apk --no-cache add ca-certificates
 COPY --from=builder /src/server .
 
-ENV ORIGIN=""
 ENV LOGLEVEL=""
+ENV ORIGIN=""
+ENV DOMAIN_CHECK_INTERVAL=""
+ENV DOMAIN_RENEWAL_INTERVAL=""
+ENV PRIVATE_KEY=""
 EXPOSE 3000
+EXPOSE 3001
 ENTRYPOINT [ "./server" ]

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/IABTechLab/adscert/internal/logger"
 	"github.com/IABTechLab/adscert/internal/utils"
@@ -21,12 +22,14 @@ import (
 )
 
 var (
-	serverPort   = flag.Int("server_port", 3000, "grpc server port")
-	metricsPort  = flag.Int("metrics_port", 3001, "http metrics port")
-	logLevel     = flag.String("loglevel", utils.GetEnvVar("LOGLEVEL"), "minimum log verbosity")
-	origin       = flag.String("origin", utils.GetEnvVar("ORIGIN"), "ads.cert hostname for the originating party")
-	privateKey   = flag.String("private_key", utils.GetEnvVar("PRIVATE_KEY"), "base-64 encoded private key")
-	signatoryApi signatory.AuthenticatedConnectionsSignatory
+	serverPort            = flag.Int("server_port", 3000, "grpc server port")
+	metricsPort           = flag.Int("metrics_port", 3001, "http metrics port")
+	logLevel              = flag.String("loglevel", utils.GetEnvVar("LOGLEVEL"), "minimum log verbosity")
+	origin                = flag.String("origin", utils.GetEnvVar("ORIGIN"), "ads.cert hostname for the originating party")
+	domainCheckInterval   = flag.Duration("domain_check_interval", 30*time.Second, "interval for checking domain records")
+	domainRenewalInterval = flag.Duration("domain_renewal_interval", 300*time.Second, "interval before considering domain records for renewal")
+	privateKey            = flag.String("private_key", utils.GetEnvVar("PRIVATE_KEY"), "base-64 encoded private key")
+	signatoryApi          signatory.AuthenticatedConnectionsSignatory
 )
 
 func main() {
@@ -45,6 +48,8 @@ func main() {
 		clock.New(),
 		discovery.NewDefaultDnsResolver(),
 		discovery.NewDefaultDomainStore(),
+		*domainCheckInterval,
+		*domainRenewalInterval,
 		[]string{*privateKey})
 
 	grpcServer := grpc.NewServer()

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -24,11 +24,11 @@ import (
 var (
 	serverPort            = flag.Int("server_port", 3000, "grpc server port")
 	metricsPort           = flag.Int("metrics_port", 3001, "http metrics port")
-	logLevel              = flag.String("loglevel", utils.GetEnvVar("LOGLEVEL"), "minimum log verbosity")
-	origin                = flag.String("origin", utils.GetEnvVar("ORIGIN"), "ads.cert hostname for the originating party")
-	domainCheckInterval   = flag.Duration("domain_check_interval", 30*time.Second, "interval for checking domain records")
-	domainRenewalInterval = flag.Duration("domain_renewal_interval", 300*time.Second, "interval before considering domain records for renewal")
-	privateKey            = flag.String("private_key", utils.GetEnvVar("PRIVATE_KEY"), "base-64 encoded private key")
+	logLevel              = flag.String("loglevel", utils.GetEnvVarString("LOGLEVEL", ""), "minimum log verbosity")
+	origin                = flag.String("origin", utils.GetEnvVarString("ORIGIN", ""), "ads.cert hostname for the originating party")
+	domainCheckInterval   = flag.Duration("domain_check_interval", time.Duration(utils.GetEnvVarInt("DOMAIN_CHECK_INTERVAL", 30))*time.Second, "interval for checking domain records")
+	domainRenewalInterval = flag.Duration("domain_renewal_interval", time.Duration(utils.GetEnvVarInt("DOMAIN_RENEWAL_INTERVAL", 300))*time.Second, "interval before considering domain records for renewal")
+	privateKey            = flag.String("private_key", utils.GetEnvVarString("PRIVATE_KEY", ""), "base-64 encoded private key")
 	signatoryApi          signatory.AuthenticatedConnectionsSignatory
 )
 
@@ -39,6 +39,11 @@ func main() {
 
 	if *origin == "" {
 		logger.Fatalf("Origin hostname is required")
+		os.Exit(returnExitCode())
+	}
+
+	if *privateKey == "" {
+		logger.Fatalf("Private key is required")
 		os.Exit(returnExitCode())
 	}
 

--- a/examples/signer-server/signer-server.go
+++ b/examples/signer-server/signer-server.go
@@ -20,12 +20,12 @@ import (
 )
 
 var (
+	origin           = flag.String("origin", "", "ads.cert identity domain for the originating (sending) party")
 	method           = flag.String("http_method", "GET", "HTTP method, 'GET' or 'POST'")
 	destinationURL   = flag.String("url", "https://google.com/gen_204", "URL to invoke")
 	body             = flag.String("body", "", "POST request body")
 	sendRequests     = flag.Bool("send_requests", false, "Actually invoke the web server")
 	frequency        = flag.Duration("frequency", 10*time.Second, "Frequency to invoke the specified URL")
-	origin           = flag.String("origin", "", "ads.cert identity domain for the originating (sending) party")
 	signatureLogFile = flag.String("signature_log_file", "", "write signature and hashes to file for offline verification")
 )
 
@@ -53,6 +53,8 @@ func main() {
 		clock.New(),
 		discovery.NewDefaultDnsResolver(),
 		discovery.NewDefaultDomainStore(),
+		time.Duration(30*time.Second), // domain check interval
+		time.Duration(30*time.Second), // domain renewal interval
 		base64PrivateKeys)
 
 	demoClient := DemoClient{

--- a/examples/verifier-parser/verifier-parser.go
+++ b/examples/verifier-parser/verifier-parser.go
@@ -7,6 +7,7 @@ import (
 	"flag"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/IABTechLab/adscert/internal/logger"
 	"github.com/IABTechLab/adscert/pkg/adscert/api"
@@ -39,6 +40,8 @@ func main() {
 		clock.New(),
 		discovery.NewDefaultDnsResolver(),
 		discovery.NewDefaultDomainStore(),
+		time.Duration(30*time.Second), // domain check interval
+		time.Duration(30*time.Second), // domain renewal interval
 		base64PrivateKeys)
 
 	var logCount, parseErrorCount, verifyErrorCount, validRequestCount, validUrlCount int

--- a/examples/verifier-server/verifier-server.go
+++ b/examples/verifier-server/verifier-server.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"time"
 
 	"github.com/IABTechLab/adscert/internal/logger"
 	"github.com/IABTechLab/adscert/pkg/adscert/api"
@@ -33,6 +34,8 @@ func main() {
 		clock.New(),
 		discovery.NewDefaultDnsResolver(),
 		discovery.NewDefaultDomainStore(),
+		time.Duration(30*time.Second), // domain check interval
+		time.Duration(30*time.Second), // domain renewal interval
 		base64PrivateKeys)
 
 	demoServer := &DemoServer{

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -2,14 +2,23 @@ package utils
 
 import (
 	"os"
+	"strconv"
 )
 
-func GetEnvVar(key string) string {
-	v, ok := os.LookupEnv(key)
-	if ok {
+func GetEnvVarString(key string, defaultValue string) string {
+	if v, ok := os.LookupEnv(key); ok {
 		return v
 	}
-	return ""
+	return defaultValue
+}
+
+func GetEnvVarInt(key string, defaultValue int) int {
+	if v, ok := os.LookupEnv(key); ok {
+		if i, err := strconv.Atoi(v); err != nil {
+			return i
+		}
+	}
+	return defaultValue
 }
 
 func MergeUniques(list []string) []string {

--- a/pkg/adscert/signatory/signatory_local_impl.go
+++ b/pkg/adscert/signatory/signatory_local_impl.go
@@ -17,12 +17,21 @@ import (
 	"github.com/benbjohnson/clock"
 )
 
-func NewLocalAuthenticatedConnectionsSignatory(originCallsign string, reader io.Reader, clock clock.Clock, dnsResolver discovery.DNSResolver, domainStore discovery.DomainStore, base64PrivateKeys []string) AuthenticatedConnectionsSignatory {
+func NewLocalAuthenticatedConnectionsSignatory(
+	originCallsign string,
+	reader io.Reader,
+	clock clock.Clock,
+	dnsResolver discovery.DNSResolver,
+	domainStore discovery.DomainStore,
+	domainCheckInterval time.Duration,
+	domainRenewalInterval time.Duration,
+	base64PrivateKeys []string) AuthenticatedConnectionsSignatory {
+
 	return &localAuthenticatedConnectionsSignatory{
 		originCallsign:      originCallsign,
 		secureRandom:        reader,
 		clock:               clock,
-		counterpartyManager: discovery.NewDefaultDomainIndexer(dnsResolver, domainStore, base64PrivateKeys),
+		counterpartyManager: discovery.NewDefaultDomainIndexer(dnsResolver, domainStore, domainCheckInterval, domainRenewalInterval, base64PrivateKeys),
 	}
 }
 


### PR DESCRIPTION
- Domain check interval and entry renewal interval are configurable values.
- Updated examples to use short 30s values for demo
- Main server reads values from command line flags or env vars with new util methods

Closes #38 