### PR TITLE
Handle multiple policy and key DNS records

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,11 @@ WORKDIR /app
 RUN apk --no-cache add ca-certificates
 COPY --from=builder /src/server .
 
-ENV ORIGIN=""
 ENV LOGLEVEL=""
+ENV ORIGIN=""
+ENV DOMAIN_CHECK_INTERVAL=""
+ENV DOMAIN_RENEWAL_INTERVAL=""
+ENV PRIVATE_KEY=""
 EXPOSE 3000
+EXPOSE 3001
 ENTRYPOINT [ "./server" ]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,57 @@
 
 ![Build/Test](https://github.com/IABTechLab/adscert/actions/workflows/go.yml/badge.svg)
 
-This is a proof of concept and not meant for use in its current form.
+**This is a proof of concept and not meant for use in its current form.**
+
+This open-source library implements the Authenticated Connections protocol, published by IAB Tech Lab let advertising industry participants secure programmatic ad buying and selling using industry-standard cryptographic security protocols.
+
+
+## Authenticated Connections Protocol
+
+Authenticated Connections uses a standardized HTTP request header containing a signature that secures:
+
+- URL being invoked
+- Body of POST requests
+- Timestamp, origin, and destination values
+
+The signature and these factors show that the request came from the originator as claimed and hasn't been tampered with. The request header looks like the following:
+
+```
+X-Ads-Cert-Auth:
+from=ssai-serving.tk&from_key=w8f316&invoking=ad-exchange.tk&nonce=u_sDzKMIp0eD&status=0&timestamp=210519T174337&to=exchange-holding-company.ga&to_key=bBvfZU; sigb=t1TupK6wn8pn&sigu=FQ5OQ6TmF2xU
+```
+
+| Field | Description |
+| --- | --- |
+| from | The domain of the party sending the request |
+| from_key | The first 6 characters of the sending party’s public key |
+| invoking | The domain for the URL hostname being invoked |
+| nonce | Randomly generated number from the sending party in base64 encoded. |
+| timestamp | The time of generating signature in format: YYMMDDTHHMMSS.  This should be in UTC. |
+| to | The domain of the party receiving the signature |
+| to_key | The first 6 characters of the receiving party’s public key |
+| sigb | The signature over the message and body of the request |
+| sigu | The signature over the message, body, and URL of the request |
+
+## Architecture
+
+- `Signatory` - Main library that handles signing and verification operations.
+- `Dns Resolver` - Discovers TXT records for a domain name (with the appropriate subdomains for policy and key records)
+- `Domain Store` - Stores domain information for invoking and identity domains and the associated keys
+- `Domain Indexer` - Uses the above components to maintain a list of domains used in signing/verification operations, runs background crawls to update domain records, stores private keys, calculates shared secrets for use by the Signatory.
+
+## API Usage
+
+The `Signatory` is available as a [standalone GRPC server](cmd/server/main.go). See the [GRPC/Protobuf interface](api/adscert.proto) for the full API details. The main function defintions are below:
+
+- `rpc SignAuthenticatedConnection(AuthenticatedConnectionSignatureRequest) returns (AuthenticatedConnectionSignatureResponse) {}`
+- `rpc VerifyAuthenticatedConnection(AuthenticatedConnectionVerificationRequest) returns (AuthenticatedConnectionVerificationResponse) {}`
+
+Clients are available for various langauges: 
+- Golang - [GRPC cient available here](api/golang) or the Signatory can be use as an [in-process Go library](pkg/adscert/signatory/signatory_local_impl.go) directly.
+- Java - Coming soon...
+- C++ - Coming soon...
+
 
 ## Examples
 
@@ -71,7 +121,7 @@ go run examples/verifier/log-parser/verifier-parser.go --origin_callsign=ssai-se
 `./internal/logger` directory holds global logger interface along with a `standard_golang_logger` implementation which is being used as default logger. Default log level is INFO. Using the `SetLoggerImpl()` method in `./internal/logger/logger.go` interface you can implement any custom logger and set it as global logger in your application.
 
 ### Modify workflows
-You can add custom workflows and github actions to `.github/workflows` folder. Currently `go.yml` includes the build and release steps including creating and pushing a new tag. A new release and tag only gets created only on main branch and push event. 
+You can add custom workflows and github actions to `.github/workflows` folder. Currently `go.yml` includes the build and release steps including creating and pushing a new tag. A new release and tag only gets created only on main branch and push event.
 [More info](https://docs.github.com/en/actions/reference/events-that-trigger-workflows).
 
 ## Contributing

--- a/cmd/keygen/main.go
+++ b/cmd/keygen/main.go
@@ -8,10 +8,6 @@ import (
 	"golang.org/x/crypto/curve25519"
 )
 
-// Curtis notes:
-// This code is really only meant to assist with the proof-of-concept.  Please see the design doc
-// for details about the proper key generation and storage solution that will replace this code.
-
 func main() {
 	publicKey, privateKey, err := GenerateKeyPair()
 	if err != nil {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/IABTechLab/adscert/internal/logger"
 	"github.com/IABTechLab/adscert/internal/utils"
@@ -21,12 +22,14 @@ import (
 )
 
 var (
-	serverPort   = flag.Int("server_port", 3000, "grpc server port")
-	metricsPort  = flag.Int("metrics_port", 3001, "http metrics port")
-	logLevel     = flag.String("loglevel", utils.GetEnvVar("LOGLEVEL"), "minimum log verbosity")
-	origin       = flag.String("origin", utils.GetEnvVar("ORIGIN"), "ads.cert hostname for the originating party")
-	privateKey   = flag.String("private_key", utils.GetEnvVar("PRIVATE_KEY"), "base-64 encoded private key")
-	signatoryApi signatory.AuthenticatedConnectionsSignatory
+	serverPort            = flag.Int("server_port", 3000, "grpc server port")
+	metricsPort           = flag.Int("metrics_port", 3001, "http metrics port")
+	logLevel              = flag.String("loglevel", utils.GetEnvVar("LOGLEVEL"), "minimum log verbosity")
+	origin                = flag.String("origin", utils.GetEnvVar("ORIGIN"), "ads.cert hostname for the originating party")
+	domainCheckInterval   = flag.Duration("domain_check_interval", 30*time.Second, "interval for checking domain records")
+	domainRenewalInterval = flag.Duration("domain_renewal_interval", 300*time.Second, "interval before considering domain records for renewal")
+	privateKey            = flag.String("private_key", utils.GetEnvVar("PRIVATE_KEY"), "base-64 encoded private key")
+	signatoryApi          signatory.AuthenticatedConnectionsSignatory
 )
 
 func main() {
@@ -45,6 +48,8 @@ func main() {
 		clock.New(),
 		discovery.NewDefaultDnsResolver(),
 		discovery.NewDefaultDomainStore(),
+		*domainCheckInterval,
+		*domainRenewalInterval,
 		[]string{*privateKey})
 
 	grpcServer := grpc.NewServer()

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -34,7 +34,7 @@ func main() {
 	logger.SetLevel(logger.GetLevelFromString(*logLevel))
 
 	// TODO: using randomly generated test certs for now
-	privateKeysBase64 := signatory.GenerateFakePrivateKeysForTesting(*origin)
+	base64PrivateKeys := signatory.GenerateFakePrivateKeysForTesting(*origin)
 
 	if *origin == "" {
 		logger.Fatalf("Origin hostname is required")
@@ -47,7 +47,7 @@ func main() {
 		clock.New(),
 		discovery.NewDefaultDnsResolver(),
 		discovery.NewDefaultDomainStore(),
-		privateKeysBase64)
+		base64PrivateKeys)
 
 	grpcServer := grpc.NewServer()
 	api.RegisterAdsCertSignatoryServer(grpcServer, &adsCertSignatoryServer{})

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -24,11 +24,11 @@ import (
 var (
 	serverPort            = flag.Int("server_port", 3000, "grpc server port")
 	metricsPort           = flag.Int("metrics_port", 3001, "http metrics port")
-	logLevel              = flag.String("loglevel", utils.GetEnvVar("LOGLEVEL"), "minimum log verbosity")
-	origin                = flag.String("origin", utils.GetEnvVar("ORIGIN"), "ads.cert hostname for the originating party")
-	domainCheckInterval   = flag.Duration("domain_check_interval", 30*time.Second, "interval for checking domain records")
-	domainRenewalInterval = flag.Duration("domain_renewal_interval", 300*time.Second, "interval before considering domain records for renewal")
-	privateKey            = flag.String("private_key", utils.GetEnvVar("PRIVATE_KEY"), "base-64 encoded private key")
+	logLevel              = flag.String("loglevel", utils.GetEnvVarString("LOGLEVEL", ""), "minimum log verbosity")
+	origin                = flag.String("origin", utils.GetEnvVarString("ORIGIN", ""), "ads.cert hostname for the originating party")
+	domainCheckInterval   = flag.Duration("domain_check_interval", time.Duration(utils.GetEnvVarInt("DOMAIN_CHECK_INTERVAL", 30))*time.Second, "interval for checking domain records")
+	domainRenewalInterval = flag.Duration("domain_renewal_interval", time.Duration(utils.GetEnvVarInt("DOMAIN_RENEWAL_INTERVAL", 300))*time.Second, "interval before considering domain records for renewal")
+	privateKey            = flag.String("private_key", utils.GetEnvVarString("PRIVATE_KEY", ""), "base-64 encoded private key")
 	signatoryApi          signatory.AuthenticatedConnectionsSignatory
 )
 
@@ -39,6 +39,11 @@ func main() {
 
 	if *origin == "" {
 		logger.Fatalf("Origin hostname is required")
+		os.Exit(returnExitCode())
+	}
+
+	if *privateKey == "" {
+		logger.Fatalf("Private key is required")
 		os.Exit(returnExitCode())
 	}
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -25,6 +25,7 @@ var (
 	metricsPort  = flag.Int("metrics_port", 3001, "http metrics port")
 	logLevel     = flag.String("loglevel", utils.GetEnvVar("LOGLEVEL"), "minimum log verbosity")
 	origin       = flag.String("origin", utils.GetEnvVar("ORIGIN"), "ads.cert hostname for the originating party")
+	privateKey   = flag.String("private_key", utils.GetEnvVar("PRIVATE_KEY"), "base-64 encoded private key")
 	signatoryApi signatory.AuthenticatedConnectionsSignatory
 )
 
@@ -32,9 +33,6 @@ func main() {
 
 	flag.Parse()
 	logger.SetLevel(logger.GetLevelFromString(*logLevel))
-
-	// TODO: using randomly generated test certs for now
-	base64PrivateKeys := signatory.GenerateFakePrivateKeysForTesting(*origin)
 
 	if *origin == "" {
 		logger.Fatalf("Origin hostname is required")
@@ -47,7 +45,7 @@ func main() {
 		clock.New(),
 		discovery.NewDefaultDnsResolver(),
 		discovery.NewDefaultDomainStore(),
-		base64PrivateKeys)
+		[]string{*privateKey})
 
 	grpcServer := grpc.NewServer()
 	api.RegisterAdsCertSignatoryServer(grpcServer, &adsCertSignatoryServer{})

--- a/examples/signer-server/signer-server.go
+++ b/examples/signer-server/signer-server.go
@@ -34,7 +34,7 @@ func main() {
 
 	logger.Infof("Starting demo client.")
 
-	privateKeysBase64 := signatory.GenerateFakePrivateKeysForTesting(*origin)
+	base64PrivateKeys := signatory.GenerateFakePrivateKeysForTesting(*origin)
 
 	var signatureFileLogger *log.Logger
 	if *signatureLogFile != "" {
@@ -53,7 +53,7 @@ func main() {
 		clock.New(),
 		discovery.NewDefaultDnsResolver(),
 		discovery.NewDefaultDomainStore(),
-		privateKeysBase64)
+		base64PrivateKeys)
 
 	demoClient := DemoClient{
 		Signatory: signatoryApi,

--- a/examples/signer-server/signer-server.go
+++ b/examples/signer-server/signer-server.go
@@ -25,7 +25,7 @@ var (
 	body             = flag.String("body", "", "POST request body")
 	sendRequests     = flag.Bool("send_requests", false, "Actually invoke the web server")
 	frequency        = flag.Duration("frequency", 10*time.Second, "Frequency to invoke the specified URL")
-	originCallsign   = flag.String("origin_callsign", "", "ads.cert callsign for the originating party")
+	origin           = flag.String("origin", "", "ads.cert identity domain for the originating (sending) party")
 	signatureLogFile = flag.String("signature_log_file", "", "write signature and hashes to file for offline verification")
 )
 
@@ -34,7 +34,7 @@ func main() {
 
 	logger.Infof("Starting demo client.")
 
-	privateKeysBase64 := signatory.GenerateFakePrivateKeysForTesting(*originCallsign)
+	privateKeysBase64 := signatory.GenerateFakePrivateKeysForTesting(*origin)
 
 	var signatureFileLogger *log.Logger
 	if *signatureLogFile != "" {
@@ -48,7 +48,7 @@ func main() {
 	}
 
 	signatoryApi := signatory.NewLocalAuthenticatedConnectionsSignatory(
-		*originCallsign,
+		*origin,
 		crypto_rand.Reader,
 		clock.New(),
 		discovery.NewDefaultDnsResolver(),

--- a/examples/signer-server/signer-server.go
+++ b/examples/signer-server/signer-server.go
@@ -20,12 +20,12 @@ import (
 )
 
 var (
+	origin           = flag.String("origin", "", "ads.cert identity domain for the originating (sending) party")
 	method           = flag.String("http_method", "GET", "HTTP method, 'GET' or 'POST'")
 	destinationURL   = flag.String("url", "https://google.com/gen_204", "URL to invoke")
 	body             = flag.String("body", "", "POST request body")
 	sendRequests     = flag.Bool("send_requests", false, "Actually invoke the web server")
 	frequency        = flag.Duration("frequency", 10*time.Second, "Frequency to invoke the specified URL")
-	origin           = flag.String("origin", "", "ads.cert identity domain for the originating (sending) party")
 	signatureLogFile = flag.String("signature_log_file", "", "write signature and hashes to file for offline verification")
 )
 
@@ -53,6 +53,8 @@ func main() {
 		clock.New(),
 		discovery.NewDefaultDnsResolver(),
 		discovery.NewDefaultDomainStore(),
+		time.Duration(30*time.Second), // domain check interval
+		time.Duration(30*time.Second), // domain renewal interval
 		base64PrivateKeys)
 
 	demoClient := DemoClient{

--- a/examples/verifier-parser/verifier-parser.go
+++ b/examples/verifier-parser/verifier-parser.go
@@ -16,8 +16,7 @@ import (
 )
 
 var (
-	hostCallsign     = flag.String("host_callsign", "", "ads.cert callsign for the host party")
-	originCallsign   = flag.String("origin_callsign", "", "ads.cert callsign for the originating party")
+	origin           = flag.String("origin", "", "ads.cert identity domain for the receiving party")
 	signatureLogFile = flag.String("signature_log_file", "", "Verify all logged signatures and hashes in file")
 )
 
@@ -32,10 +31,10 @@ func main() {
 	}
 	defer file.Close()
 
-	privateKeysBase64 := signatory.GenerateFakePrivateKeysForTesting(*hostCallsign)
+	privateKeysBase64 := signatory.GenerateFakePrivateKeysForTesting(*origin)
 
 	signatoryApi := signatory.NewLocalAuthenticatedConnectionsSignatory(
-		*hostCallsign,
+		*origin,
 		crypto_rand.Reader,
 		clock.New(),
 		discovery.NewDefaultDnsResolver(),

--- a/examples/verifier-parser/verifier-parser.go
+++ b/examples/verifier-parser/verifier-parser.go
@@ -31,7 +31,7 @@ func main() {
 	}
 	defer file.Close()
 
-	privateKeysBase64 := signatory.GenerateFakePrivateKeysForTesting(*origin)
+	base64PrivateKeys := signatory.GenerateFakePrivateKeysForTesting(*origin)
 
 	signatoryApi := signatory.NewLocalAuthenticatedConnectionsSignatory(
 		*origin,
@@ -39,7 +39,7 @@ func main() {
 		clock.New(),
 		discovery.NewDefaultDnsResolver(),
 		discovery.NewDefaultDomainStore(),
-		privateKeysBase64)
+		base64PrivateKeys)
 
 	var logCount, parseErrorCount, verifyErrorCount, validRequestCount, validUrlCount int
 

--- a/examples/verifier-parser/verifier-parser.go
+++ b/examples/verifier-parser/verifier-parser.go
@@ -7,6 +7,7 @@ import (
 	"flag"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/IABTechLab/adscert/internal/logger"
 	"github.com/IABTechLab/adscert/pkg/adscert/api"
@@ -39,6 +40,8 @@ func main() {
 		clock.New(),
 		discovery.NewDefaultDnsResolver(),
 		discovery.NewDefaultDomainStore(),
+		time.Duration(30*time.Second), // domain check interval
+		time.Duration(30*time.Second), // domain renewal interval
 		base64PrivateKeys)
 
 	var logCount, parseErrorCount, verifyErrorCount, validRequestCount, validUrlCount int

--- a/examples/verifier-server/verifier-server.go
+++ b/examples/verifier-server/verifier-server.go
@@ -25,7 +25,7 @@ func main() {
 
 	logger.Infof("Starting demo server.")
 
-	privateKeysBase64 := signatory.GenerateFakePrivateKeysForTesting(*origin)
+	base64PrivateKeys := signatory.GenerateFakePrivateKeysForTesting(*origin)
 
 	signatoryApi := signatory.NewLocalAuthenticatedConnectionsSignatory(
 		*origin,
@@ -33,7 +33,7 @@ func main() {
 		clock.New(),
 		discovery.NewDefaultDnsResolver(),
 		discovery.NewDefaultDomainStore(),
-		privateKeysBase64)
+		base64PrivateKeys)
 
 	demoServer := &DemoServer{
 		Signatory: signatoryApi,

--- a/examples/verifier-server/verifier-server.go
+++ b/examples/verifier-server/verifier-server.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"time"
 
 	"github.com/IABTechLab/adscert/internal/logger"
 	"github.com/IABTechLab/adscert/pkg/adscert/api"
@@ -33,6 +34,8 @@ func main() {
 		clock.New(),
 		discovery.NewDefaultDnsResolver(),
 		discovery.NewDefaultDomainStore(),
+		time.Duration(30*time.Second), // domain check interval
+		time.Duration(30*time.Second), // domain renewal interval
 		base64PrivateKeys)
 
 	demoServer := &DemoServer{

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -2,14 +2,23 @@ package utils
 
 import (
 	"os"
+	"strconv"
 )
 
-func GetEnvVar(key string) string {
-	v, ok := os.LookupEnv(key)
-	if ok {
+func GetEnvVarString(key string, defaultValue string) string {
+	if v, ok := os.LookupEnv(key); ok {
 		return v
 	}
-	return ""
+	return defaultValue
+}
+
+func GetEnvVarInt(key string, defaultValue int) int {
+	if v, ok := os.LookupEnv(key); ok {
+		if i, err := strconv.Atoi(v); err != nil {
+			return i
+		}
+	}
+	return defaultValue
 }
 
 func MergeUniques(list []string) []string {

--- a/pkg/adscert/discovery/domain_indexer_impl.go
+++ b/pkg/adscert/discovery/domain_indexer_impl.go
@@ -154,7 +154,7 @@ func (di *defaultDomainIndexer) checkDomainForPolicyRecords(ctx context.Context,
 	baseSubdomainRecords, err := di.dnsResolver.LookupTXT(ctx, baseSubdomain)
 
 	if err != nil {
-		logger.Warningf("Error looking up record for %s in %v: %v", baseSubdomain, time.Since(startTime), err)
+		logger.Warningf("No record found for %s in %v: %v", baseSubdomain, time.Since(startTime), err)
 		return
 
 	} else {
@@ -194,7 +194,7 @@ func (di *defaultDomainIndexer) checkDomainForKeyRecords(ctx context.Context, cu
 	deliverySubdomainRecords, err := di.dnsResolver.LookupTXT(ctx, deliverySubdomain)
 
 	if err != nil {
-		logger.Warningf("Error looking up record for %s in %v: %v", deliverySubdomain, time.Since(startTime), err)
+		logger.Warningf("No record found for %s in %v: %v", deliverySubdomain, time.Since(startTime), err)
 		return
 
 	} else {

--- a/pkg/adscert/discovery/domain_indexer_impl.go
+++ b/pkg/adscert/discovery/domain_indexer_impl.go
@@ -225,8 +225,6 @@ func (di *defaultDomainIndexer) checkDomainForKeyRecords(ctx context.Context, cu
 		} else if len(adsCertKeys.PublicKeys) > 0 {
 			currentDomainInfo.allPublicKeys = asKeyMap(*adsCertKeys)
 			currentDomainInfo.currentPublicKeyId = keyAlias(adsCertKeys.PublicKeys[0].KeyAlias)
-			currentDomainInfo.allSharedSecrets = keyPairMap{}
-			currentDomainInfo.currentSharedSecretId = keyPairAlias{}
 			currentDomainInfo.protocolStatus = formats.StatusOK
 			metrics.RecordDNSLookup(nil)
 		}
@@ -268,7 +266,13 @@ func (di *defaultDomainIndexer) UpdateNow() {
 
 func initializeDomainInfo(domain string) DomainInfo {
 	return DomainInfo{
-		Domain:         domain,
-		protocolStatus: formats.StatusNotYetChecked, // this is the proper initialize status, do not use Unspecified as that is an error condition
+		Domain:                domain,
+		IdentityDomains:       []string{},
+		currentPublicKeyId:    "",
+		currentSharedSecretId: keyPairAlias{},
+		allPublicKeys:         map[keyAlias]*x25519Key{},
+		allSharedSecrets:      keyPairMap{},
+		protocolStatus:        formats.StatusNotYetChecked,
+		lastUpdateTime:        time.Time{},
 	}
 }

--- a/pkg/adscert/signatory/crypto_testing.go
+++ b/pkg/adscert/signatory/crypto_testing.go
@@ -1,13 +1,10 @@
 package signatory
 
 import (
-	"context"
 	"crypto/sha256"
 	"encoding/base64"
 	"fmt"
 
-	"github.com/IABTechLab/adscert/internal/logger"
-	"github.com/IABTechLab/adscert/pkg/adscert/discovery"
 	"golang.org/x/crypto/curve25519"
 )
 
@@ -30,16 +27,4 @@ func GenerateFakeKeyPairFromDomainNameForTesting(adscertCallsign string) ([32]by
 	var publicKey [32]byte
 	curve25519.ScalarBaseMult(&publicKey, &privateKey)
 	return publicKey, privateKey
-}
-
-type keyGeneratingDNSResolver struct{}
-
-func (r *keyGeneratingDNSResolver) LookupTXT(ctx context.Context, name string) ([]string, error) {
-	adsCertRecord := GenerateFakeAdsCertRecordForTesting(name)
-	logger.Infof("Serving fake DNS record for %s: %s", name, adsCertRecord)
-	return []string{adsCertRecord}, nil
-}
-
-func NewFakeKeyGeneratingDnsResolver() discovery.DNSResolver {
-	return &keyGeneratingDNSResolver{}
 }

--- a/pkg/adscert/signatory/signatory_local_impl.go
+++ b/pkg/adscert/signatory/signatory_local_impl.go
@@ -17,12 +17,21 @@ import (
 	"github.com/benbjohnson/clock"
 )
 
-func NewLocalAuthenticatedConnectionsSignatory(originCallsign string, reader io.Reader, clock clock.Clock, dnsResolver discovery.DNSResolver, domainStore discovery.DomainStore, base64PrivateKeys []string) AuthenticatedConnectionsSignatory {
+func NewLocalAuthenticatedConnectionsSignatory(
+	originCallsign string,
+	reader io.Reader,
+	clock clock.Clock,
+	dnsResolver discovery.DNSResolver,
+	domainStore discovery.DomainStore,
+	domainCheckInterval time.Duration,
+	domainRenewalInterval time.Duration,
+	base64PrivateKeys []string) AuthenticatedConnectionsSignatory {
+
 	return &localAuthenticatedConnectionsSignatory{
 		originCallsign:      originCallsign,
 		secureRandom:        reader,
 		clock:               clock,
-		counterpartyManager: discovery.NewDefaultDomainIndexer(dnsResolver, domainStore, base64PrivateKeys),
+		counterpartyManager: discovery.NewDefaultDomainIndexer(dnsResolver, domainStore, domainCheckInterval, domainRenewalInterval, base64PrivateKeys),
 	}
 }
 

--- a/pkg/adscert/signatory/signatory_local_impl.go
+++ b/pkg/adscert/signatory/signatory_local_impl.go
@@ -17,12 +17,12 @@ import (
 	"github.com/benbjohnson/clock"
 )
 
-func NewLocalAuthenticatedConnectionsSignatory(originCallsign string, reader io.Reader, clock clock.Clock, dnsResolver discovery.DNSResolver, domainStore discovery.DomainStore, privateKeyBase64Strings []string) AuthenticatedConnectionsSignatory {
+func NewLocalAuthenticatedConnectionsSignatory(originCallsign string, reader io.Reader, clock clock.Clock, dnsResolver discovery.DNSResolver, domainStore discovery.DomainStore, base64PrivateKeys []string) AuthenticatedConnectionsSignatory {
 	return &localAuthenticatedConnectionsSignatory{
 		originCallsign:      originCallsign,
 		secureRandom:        reader,
 		clock:               clock,
-		counterpartyManager: discovery.NewDefaultDomainIndexer(dnsResolver, domainStore, privateKeyBase64Strings),
+		counterpartyManager: discovery.NewDefaultDomainIndexer(dnsResolver, domainStore, base64PrivateKeys),
 	}
 }
 


### PR DESCRIPTION
- Handle multiple policy and key records for domain lookup
- Adjust logging messages to show warnings but not errors since multiple records are allowed (during migration of domain ownership or key rotation).
- New domain indexer behavior is to replace the current domain info with the new (policy or key) info upon successful parsing of all records found in the current update.

Closes #33 