### PR TITLE
Fix a SIGSEGV in signSingleMessage - sigInfo always nil

### DIFF
--- a/pkg/adscert/signatory/signatory_local_impl.go
+++ b/pkg/adscert/signatory/signatory_local_impl.go
@@ -89,8 +89,9 @@ func (s *localAuthenticatedConnectionsSignatory) SignAuthenticatedConnection(req
 	return response, nil
 }
 
-func (s *localAuthenticatedConnectionsSignatory) signSingleMessage(request *api.AuthenticatedConnectionSignatureRequest, domainInfo discovery.DomainInfo) (sigInfo *api.SignatureInfo, err error) {
+func (s *localAuthenticatedConnectionsSignatory) signSingleMessage(request *api.AuthenticatedConnectionSignatureRequest, domainInfo discovery.DomainInfo) (*api.SignatureInfo, error) {
 
+	sigInfo := &api.SignatureInfo{}
 	acs, err := formats.NewAuthenticatedConnectionSignature(formats.StatusOK, s.originCallsign, request.RequestInfo.InvokingDomain)
 	if err != nil {
 		acs.SetStatus(formats.StatusErrorOnSignature)


### PR DESCRIPTION
I know the library is not ready for use, but when building an example client and server, I discovered a SIGSEV that occurs because the named return value `sigInfo` in `signSingleMessage` is always `nil`.

