### PR TITLE
build and deploy docker image on push to main

### DIFF
--- a/.github/workflows/build-and-release-on-push.yml
+++ b/.github/workflows/build-and-release-on-push.yml
@@ -35,6 +35,14 @@ jobs:
     - name: Test
       run: go test -v ./...
 
+    - name: Build and Push Docker Image
+    uses: mr-smithers-excellent/docker-build-push@v5
+    with:
+      image: adscert
+      registry: ghcr.io
+      username: ${{ secrets.GHCR_USERNAME }}
+      password: ${{ secrets.GITHUB_TOKEN }}
+
   Release:
     name: Create Release
     runs-on: ubuntu-latest


### PR DESCRIPTION
Builds docker image and deploys image to repo's GitHub package manager on pushes to the repo's main branch.

Requires a secret to be added to the repo containing the owners github username.

https://screenshot.googleplex.com/37YKCucAC2FNNSK