### PR TITLE
Testsign command

### DIFF
--- a/.github/workflows/build-and-release-on-push.yml
+++ b/.github/workflows/build-and-release-on-push.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.16
+        go-version: 1.17
 
     # Install all the dependencies
     - name: Install dependencies

--- a/.github/workflows/build-on-pull-request.yml
+++ b/.github/workflows/build-on-pull-request.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.16
+        go-version: 1.17
 
     # Install all the dependencies
     - name: Install dependencies

--- a/cmd/testsign.go
+++ b/cmd/testsign.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"github.com/spf13/cobra"
 	"time"
-	// "fmt"
 
 	"github.com/IABTechLab/adscert/pkg/adscert/api"
 	"github.com/IABTechLab/adscert/pkg/adscert/logger"
@@ -30,15 +29,14 @@ import (
 	"google.golang.org/protobuf/encoding/prototext"
 )
 
-// signatoryCmd represents the signatory command
+// testsignCmd represents the test sign command
 var (
 	testsignParams = &testsignParameters{url: "google.com"}
 
 	testsignCmd = &cobra.Command{
 		Use:   "testsign",
-		Short: " Given a URL to invoke, generate a signature. Optionally, actually invoke the URL",
+		Short: " Given a URL to invoke, generate a signature.",
 		Run: func(cmd *cobra.Command, args []string) {
-			// fmt.Printf("generated signature: %d\n", signUrl((*testsignParams).url))
 			signRequest(testsignParams)
 		},
 	}
@@ -60,11 +58,6 @@ func init() {
 	testsignCmd.Flags().StringVar(&testsignParams.body, "body", "", "POST request body")
 	testsignCmd.Flags().DurationVar(&testsignParams.signingTimeout, "signing_timeout", 5*time.Millisecond, "Specifies how long this client will wait for signing to finish before abandoning.")
 }
-
-// func signURL(testsignParams *testsignParameters) {
-// 	// todo: implement
-// 	fmt.Printf("url to sign: %s\n", testsignParams.url)
-// }
 
 func signRequest(testsignParams *testsignParameters) {
 

--- a/cmd/testsign.go
+++ b/cmd/testsign.go
@@ -1,0 +1,128 @@
+/*
+Copyright © 2022 IAB Technology Laboratory, Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"context"
+	"github.com/spf13/cobra"
+	"time"
+	// "fmt"
+
+	"github.com/IABTechLab/adscert/pkg/adscert/api"
+	"github.com/IABTechLab/adscert/pkg/adscert/logger"
+	"github.com/IABTechLab/adscert/pkg/adscert/signatory"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/protobuf/encoding/prototext"
+)
+
+// signatoryCmd represents the signatory command
+var (
+	testsignParams = &testsignParameters{url: "google.com"}
+
+	testsignCmd = &cobra.Command{
+		Use:   "testsign",
+		Short: " Given a URL to invoke, generate a signature. Optionally, actually invoke the URL",
+		Run: func(cmd *cobra.Command, args []string) {
+			// fmt.Printf("generated signature: %d\n", signUrl((*testsignParams).url))
+			signRequest(testsignParams)
+		},
+	}
+)
+
+type testsignParameters struct {
+	url            string
+	serverAddress  string
+	destinationURL string
+	body           string
+	signingTimeout time.Duration
+}
+
+func init() {
+	rootCmd.AddCommand(testsignCmd)
+
+	testsignCmd.Flags().StringVar(&testsignParams.destinationURL, "url", "https://google.com/", "URL to invoke")
+	testsignCmd.Flags().StringVar(&testsignParams.serverAddress, "server_address", "localhost:3000", "address of grpc server")
+	testsignCmd.Flags().StringVar(&testsignParams.body, "body", "", "POST request body")
+	testsignCmd.Flags().DurationVar(&testsignParams.signingTimeout, "signing_timeout", 5*time.Millisecond, "Specifies how long this client will wait for signing to finish before abandoning.")
+}
+
+// func signURL(testsignParams *testsignParameters) {
+// 	// todo: implement
+// 	fmt.Printf("url to sign: %s\n", testsignParams.url)
+// }
+
+func signRequest(testsignParams *testsignParameters) {
+
+	// Establish the gRPC connection that the client will use to connect to the
+	// signatory server.  This basic example uses unauthenticated connections
+	// which should not be used in a production environment.
+	opts := []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}
+	conn, err := grpc.Dial(testsignParams.serverAddress, opts...)
+	if err != nil {
+		logger.Fatalf("Failed to dial: %v", err)
+	}
+	defer conn.Close()
+
+	// Optional: performs a health check against the server before actually
+	// trying to invoke the signatory service.
+
+	performOptionalHealthCheckRPC(conn)
+
+	// Create a reusable Signatory Client that provides a lightweight wrapper
+	// around the RPC client stub.  This code performs some basic request
+	// timeout and error handling logic.
+	clientOpts := &signatory.AuthenticatedConnectionsSignatoryClientOptions{Timeout: testsignParams.signingTimeout}
+	signatoryClient := signatory.NewAuthenticatedConnectionsSignatoryClient(conn, clientOpts)
+
+	// The RequestInfo proto contains details about the individual ad request
+	// being signed.  A SetRequestInfo helper function derives a hash of the
+	// destination URL and body, setting these value on the RequestInfo message.
+	reqInfo := &api.RequestInfo{}
+	signatory.SetRequestInfo(reqInfo, testsignParams.destinationURL, []byte(testsignParams.body))
+
+	// Request the signature.
+	logger.Infof("signing request for url: %v", testsignParams.destinationURL)
+	signatureResponse, err := signatoryClient.SignAuthenticatedConnection(
+		&api.AuthenticatedConnectionSignatureRequest{
+			RequestInfo: reqInfo,
+		})
+	if err != nil {
+		logger.Warningf("unable to sign message: %v", err)
+	}
+
+	// In most circumstances a signatureResponse will be returned which includes
+	// detals about the successful or failed signature attempt.
+	if signatureResponse != nil {
+		logger.Infof("signature response:\n%s", prototext.Format(signatureResponse))
+	} else {
+		logger.Warningf("signature response is missing")
+	}
+}
+
+func performOptionalHealthCheckRPC(conn *grpc.ClientConn) {
+	hctx, hcancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer hcancel()
+	healthClient := grpc_health_v1.NewHealthClient(conn)
+	healthCheckResponse, err := healthClient.Check(hctx, &grpc_health_v1.HealthCheckRequest{})
+	if err != nil {
+		logger.Fatalf("Failed to pass heath check: %v", err)
+	}
+	if healthCheckResponse.Status != grpc_health_v1.HealthCheckResponse_SERVING {
+		logger.Fatalf("Failed to pass heath status: %v", healthCheckResponse.Status)
+	}
+}

--- a/cmd/testsign.go
+++ b/cmd/testsign.go
@@ -16,26 +16,25 @@ limitations under the License.
 package cmd
 
 import (
-	"context"
-	"github.com/spf13/cobra"
 	"time"
+
+	"github.com/spf13/cobra"
 
 	"github.com/IABTechLab/adscert/pkg/adscert/api"
 	"github.com/IABTechLab/adscert/pkg/adscert/logger"
 	"github.com/IABTechLab/adscert/pkg/adscert/signatory"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
-	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/protobuf/encoding/prototext"
 )
 
 // testsignCmd represents the test sign command
 var (
-	testsignParams = &testsignParameters{url: "google.com"}
+	testsignParams = &testsignParameters{}
 
 	testsignCmd = &cobra.Command{
 		Use:   "testsign",
-		Short: " Given a URL to invoke, generate a signature.",
+		Short: "Given a URL to invoke (and optionally, a request body) generate a signature.",
 		Run: func(cmd *cobra.Command, args []string) {
 			signRequest(testsignParams)
 		},
@@ -45,7 +44,6 @@ var (
 type testsignParameters struct {
 	url            string
 	serverAddress  string
-	destinationURL string
 	body           string
 	signingTimeout time.Duration
 }
@@ -53,7 +51,7 @@ type testsignParameters struct {
 func init() {
 	rootCmd.AddCommand(testsignCmd)
 
-	testsignCmd.Flags().StringVar(&testsignParams.destinationURL, "url", "https://google.com/", "URL to invoke")
+	testsignCmd.Flags().StringVar(&testsignParams.url, "url", "", "URL to invoke")
 	testsignCmd.Flags().StringVar(&testsignParams.serverAddress, "server_address", "localhost:3000", "address of grpc server")
 	testsignCmd.Flags().StringVar(&testsignParams.body, "body", "", "POST request body")
 	testsignCmd.Flags().DurationVar(&testsignParams.signingTimeout, "signing_timeout", 5*time.Millisecond, "Specifies how long this client will wait for signing to finish before abandoning.")
@@ -71,11 +69,6 @@ func signRequest(testsignParams *testsignParameters) {
 	}
 	defer conn.Close()
 
-	// Optional: performs a health check against the server before actually
-	// trying to invoke the signatory service.
-
-	performOptionalHealthCheckRPC(conn)
-
 	// Create a reusable Signatory Client that provides a lightweight wrapper
 	// around the RPC client stub.  This code performs some basic request
 	// timeout and error handling logic.
@@ -86,10 +79,10 @@ func signRequest(testsignParams *testsignParameters) {
 	// being signed.  A SetRequestInfo helper function derives a hash of the
 	// destination URL and body, setting these value on the RequestInfo message.
 	reqInfo := &api.RequestInfo{}
-	signatory.SetRequestInfo(reqInfo, testsignParams.destinationURL, []byte(testsignParams.body))
+	signatory.SetRequestInfo(reqInfo, testsignParams.url, []byte(testsignParams.body))
 
 	// Request the signature.
-	logger.Infof("signing request for url: %v", testsignParams.destinationURL)
+	logger.Infof("signing request for url: %v", testsignParams.url)
 	signatureResponse, err := signatoryClient.SignAuthenticatedConnection(
 		&api.AuthenticatedConnectionSignatureRequest{
 			RequestInfo: reqInfo,
@@ -104,18 +97,5 @@ func signRequest(testsignParams *testsignParameters) {
 		logger.Infof("signature response:\n%s", prototext.Format(signatureResponse))
 	} else {
 		logger.Warningf("signature response is missing")
-	}
-}
-
-func performOptionalHealthCheckRPC(conn *grpc.ClientConn) {
-	hctx, hcancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
-	defer hcancel()
-	healthClient := grpc_health_v1.NewHealthClient(conn)
-	healthCheckResponse, err := healthClient.Check(hctx, &grpc_health_v1.HealthCheckRequest{})
-	if err != nil {
-		logger.Fatalf("Failed to pass heath check: %v", err)
-	}
-	if healthCheckResponse.Status != grpc_health_v1.HealthCheckResponse_SERVING {
-		logger.Fatalf("Failed to pass heath status: %v", healthCheckResponse.Status)
 	}
 }

--- a/go.sum
+++ b/go.sum
@@ -176,7 +176,6 @@ github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.7 h1:81/ik6ipDQS2aGcBfIN5dHDB36BwrStyeAQquSYCV4o=
 github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
@@ -328,10 +327,7 @@ github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXP
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
 github.com/prometheus/client_golang v1.4.0/go.mod h1:e9GMxYsXl05ICDXkRhurwBS4Q3OK1iX/F2sw+iXX5zU=
 github.com/prometheus/client_golang v1.7.1/go.mod h1:PY5Wy2awLA44sXw4AOSfFBetzPP4j5+D6mVACh+pe2M=
-github.com/prometheus/client_golang v1.11.0 h1:HNkLOAEQMIDv/K+04rukrLx6ch7msSRwf3/SASFAGtQ=
 github.com/prometheus/client_golang v1.11.0/go.mod h1:Z6t4BnS23TR94PD6BsDNk8yVqroYurpAkEiz0P2BEV0=
-github.com/prometheus/client_golang v1.12.0 h1:C+UIj/QWtmqY13Arb8kwMt5j34/0Z2iKamrJ+ryC0Gg=
-github.com/prometheus/client_golang v1.12.0/go.mod h1:3Z9XVyYiZYEO+YQWt3RD2R3jrbd179Rt297l4aS6nDY=
 github.com/prometheus/client_golang v1.12.1 h1:ZiaPsmm9uiBeaSMRznKsCDNtPCS0T3JVDGF+06gjBzk=
 github.com/prometheus/client_golang v1.12.1/go.mod h1:3Z9XVyYiZYEO+YQWt3RD2R3jrbd179Rt297l4aS6nDY=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
@@ -342,7 +338,6 @@ github.com/prometheus/client_model v0.2.0/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6T
 github.com/prometheus/common v0.4.1/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
 github.com/prometheus/common v0.9.1/go.mod h1:yhUN8i9wzaXS3w1O07YhxHEBxD+W35wd8bs7vj7HSQ4=
 github.com/prometheus/common v0.10.0/go.mod h1:Tlit/dnDKsSWFlCLTWaA1cyBgKHSMdTB80sz/V91rCo=
-github.com/prometheus/common v0.26.0 h1:iMAkS2TDoNWnKM+Kopnx/8tnEStIfpYA0ur0xQzzhMQ=
 github.com/prometheus/common v0.26.0/go.mod h1:M7rCNAaPfAosfx8veZJCuw84e35h3Cfd9VFqTh1DIvc=
 github.com/prometheus/common v0.32.1 h1:hWIdL3N2HoUx3B8j3YN9mWor0qhY/NlEKZEaXxuIRh4=
 github.com/prometheus/common v0.32.1/go.mod h1:vu+V0TpY+O6vW9J44gczi3Ap/oXXR10b+M/gUGO4Hls=
@@ -350,7 +345,6 @@ github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
 github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
-github.com/prometheus/procfs v0.6.0 h1:mxy4L2jP6qMonqmq+aTtOx1ifVWUgG/TAmntgbh3xv4=
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/procfs v0.7.3 h1:4jVXhlkAyzOScmCkXBTOLRLTz8EeU+eyjrwB/EPq0VU=
 github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
@@ -415,8 +409,6 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210817164053-32db794688a5/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
-golang.org/x/crypto v0.0.0-20220112180741-5e0467b6c7ce h1:Roh6XWxHFKrPgC/EQhVubSAGQ6Ozk6IdxHSzt1mR0EI=
-golang.org/x/crypto v0.0.0-20220112180741-5e0467b6c7ce/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.0.0-20220131195533-30dcbda58838 h1:71vQrMauZZhcTVK6KdYM+rklehEEwb3E+ZhaE5jrPrE=
 golang.org/x/crypto v0.0.0-20220131195533-30dcbda58838/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -498,10 +490,6 @@ golang.org/x/net v0.0.0-20210503060351-7fd8e65b6420/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/net v0.0.0-20210525063256-abc453219eb5/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210813160813-60bc85c4be6d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/net v0.0.0-20220111093109-d55c255bac03 h1:0FB83qp0AzVJm+0wcIlauAjJ+tNdh7jLuacRYCIVv7s=
-golang.org/x/net v0.0.0-20220111093109-d55c255bac03/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/net v0.0.0-20220121210141-e204ce36a2ba h1:6u6sik+bn/y7vILcYkK3iwTBWN7WtBvB0+SZswQnbf8=
-golang.org/x/net v0.0.0-20220121210141-e204ce36a2ba/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd h1:O7DYs+zxREGLKzKoMQrtrEacpb0ZVXA5rIwylE2Xchk=
 golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -606,8 +594,6 @@ golang.org/x/sys v0.0.0-20211007075335-d3039528d8ac/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211124211545-fe61309f8881/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211205182925-97ca703d548d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220111092808-5a964db01320 h1:0jf+tOCoZ3LyutmCOWpVni1chK4VfFLhRsDK7MhqGRY=
-golang.org/x/sys v0.0.0-20220111092808-5a964db01320/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9 h1:XfKQ4OlFl8okEOr5UvAqFRVj8pY/4yfcXrddB8qAbU0=
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
@@ -789,10 +775,6 @@ google.golang.org/genproto v0.0.0-20211129164237-f09f9a12af12/go.mod h1:5CzLGKJ6
 google.golang.org/genproto v0.0.0-20211203200212-54befc351ae9/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
 google.golang.org/genproto v0.0.0-20211206160659-862468c7d6e0/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
 google.golang.org/genproto v0.0.0-20211208223120-3a66f561d7aa/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
-google.golang.org/genproto v0.0.0-20220112215332-a9c7c0acf9f2 h1:z+R4M/SuyaRsj1zu3WC+nIQyfSrSIpuDcY01/R3uCtg=
-google.golang.org/genproto v0.0.0-20220112215332-a9c7c0acf9f2/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
-google.golang.org/genproto v0.0.0-20220118154757-00ab72f36ad5 h1:zzNejm+EgrbLfDZ6lu9Uud2IVvHySPl8vQzf04laR5Q=
-google.golang.org/genproto v0.0.0-20220118154757-00ab72f36ad5/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
 google.golang.org/genproto v0.0.0-20220126215142-9970aeb2e350 h1:YxHp5zqIcAShDEvRr5/0rVESVS+njYF68PSdazrNLJo=
 google.golang.org/genproto v0.0.0-20220126215142-9970aeb2e350/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
 google.golang.org/grpc v1.14.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
@@ -824,8 +806,6 @@ google.golang.org/grpc v1.39.1/go.mod h1:PImNr+rS9TWYb2O4/emRugxiyHZ5JyHW5F+RPnD
 google.golang.org/grpc v1.40.0/go.mod h1:ogyxbiOoUXAkP+4+xa6PZSE9DZgIHtSpzjDTB9KAK34=
 google.golang.org/grpc v1.40.1/go.mod h1:ogyxbiOoUXAkP+4+xa6PZSE9DZgIHtSpzjDTB9KAK34=
 google.golang.org/grpc v1.42.0/go.mod h1:k+4IHHFw41K8+bbowsex27ge2rCb65oeWqe4jJ590SU=
-google.golang.org/grpc v1.43.0 h1:Eeu7bZtDZ2DpRCsLhUlcrLnvYaMK1Gz86a+hMVvELmM=
-google.golang.org/grpc v1.43.0/go.mod h1:k+4IHHFw41K8+bbowsex27ge2rCb65oeWqe4jJ590SU=
 google.golang.org/grpc v1.44.0 h1:weqSxi/TMs1SqFRMHCtBgXRs8k3X39QIDEZ0pRcttUg=
 google.golang.org/grpc v1.44.0/go.mod h1:k+4IHHFw41K8+bbowsex27ge2rCb65oeWqe4jJ590SU=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=


### PR DESCRIPTION
Implements test sign command.

Command connects client to local signatory over port 3000, and provides a url to be signed. The signatory responds with a signature over the url, generated using the signatory's private key and the public key of the invoked party. 

The Invoked party must have a published public key for the signing to succeed. This command will fail on its first run, as the signatory will not yet have stored a public key for the invoked party. Failure will result in the public key being looked up and stored, and subsequent signing attempts will succeed.  

Example syntax: go run . testsign --url "https://example.com" 
** a signatory must be running locally at port 3000 before this command is run